### PR TITLE
修改License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Attribution-ShareAlike 4.0 International
+Attribution-NonCommercial-ShareAlike 4.0 International
 
 =======================================================================
 
@@ -33,7 +33,7 @@ exhaustive, and do not form part of our licenses.
      material not subject to the license. This includes other CC-
      licensed material, or material used under an exception or
      limitation to copyright. More considerations for licensors:
-     wiki.creativecommons.org/Considerations_for_licensors
+    wiki.creativecommons.org/Considerations_for_licensors
 
      Considerations for the public: By using one of our public
      licenses, a licensor grants the public permission to use the
@@ -50,22 +50,22 @@ exhaustive, and do not form part of our licenses.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More considerations
      for the public:
-     wiki.creativecommons.org/Considerations_for_licensees
+    wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 
-Creative Commons Attribution-ShareAlike 4.0 International Public
-License
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+Public License
 
 By exercising the Licensed Rights (defined below), You accept and agree
 to be bound by the terms and conditions of this Creative Commons
-Attribution-ShareAlike 4.0 International Public License ("Public
-License"). To the extent this Public License may be interpreted as a
-contract, You are granted the Licensed Rights in consideration of Your
-acceptance of these terms and conditions, and the Licensor grants You
-such rights in consideration of benefits the Licensor receives from
-making the Licensed Material available under these terms and
-conditions.
+Attribution-NonCommercial-ShareAlike 4.0 International Public License
+("Public License"). To the extent this Public License may be
+interpreted as a contract, You are granted the Licensed Rights in
+consideration of Your acceptance of these terms and conditions, and the
+Licensor grants You such rights in consideration of benefits the
+Licensor receives from making the Licensed Material available under
+these terms and conditions.
 
 
 Section 1 -- Definitions.
@@ -84,7 +84,7 @@ Section 1 -- Definitions.
      and Similar Rights in Your contributions to Adapted Material in
      accordance with the terms and conditions of this Public License.
 
-  c. BY-SA Compatible License means a license listed at
+  c. BY-NC-SA Compatible License means a license listed at
      creativecommons.org/compatiblelicenses, approved by Creative
      Commons as essentially the equivalent of this Public License.
 
@@ -108,7 +108,7 @@ Section 1 -- Definitions.
 
   g. License Elements means the license attributes listed in the name
      of a Creative Commons Public License. The License Elements of this
-     Public License are Attribution and ShareAlike.
+     Public License are Attribution, NonCommercial, and ShareAlike.
 
   h. Licensed Material means the artistic or literary work, database,
      or other material to which the Licensor applied this Public
@@ -122,7 +122,15 @@ Section 1 -- Definitions.
   j. Licensor means the individual(s) or entity(ies) granting rights
      under this Public License.
 
-  k. Share means to provide material to the public by any means or
+  k. NonCommercial means not primarily intended for or directed towards
+     commercial advantage or monetary compensation. For purposes of
+     this Public License, the exchange of the Licensed Material for
+     other material subject to Copyright and Similar Rights by digital
+     file-sharing or similar means is NonCommercial provided there is
+     no payment of monetary compensation in connection with the
+     exchange.
+
+  l. Share means to provide material to the public by any means or
      process that requires permission under the Licensed Rights, such
      as reproduction, public display, public performance, distribution,
      dissemination, communication, or importation, and to make material
@@ -130,13 +138,13 @@ Section 1 -- Definitions.
      public may access the material from a place and at a time
      individually chosen by them.
 
-  l. Sui Generis Database Rights means rights other than copyright
+  m. Sui Generis Database Rights means rights other than copyright
      resulting from Directive 96/9/EC of the European Parliament and of
      the Council of 11 March 1996 on the legal protection of databases,
      as amended and/or succeeded, as well as other essentially
      equivalent rights anywhere in the world.
 
-  m. You means the individual or entity exercising the Licensed Rights
+  n. You means the individual or entity exercising the Licensed Rights
      under this Public License. Your has a corresponding meaning.
 
 
@@ -150,9 +158,10 @@ Section 2 -- Scope.
           exercise the Licensed Rights in the Licensed Material to:
 
             a. reproduce and Share the Licensed Material, in whole or
-               in part; and
+               in part, for NonCommercial purposes only; and
 
-            b. produce, reproduce, and Share Adapted Material.
+            b. produce, reproduce, and Share Adapted Material for
+               NonCommercial purposes only.
 
        2. Exceptions and Limitations. For the avoidance of doubt, where
           Exceptions and Limitations apply to Your use, this Public
@@ -220,7 +229,9 @@ Section 2 -- Scope.
           Rights, whether directly or through a collecting society
           under any voluntary or waivable statutory or compulsory
           licensing scheme. In all other cases the Licensor expressly
-          reserves any right to collect such royalties.
+          reserves any right to collect such royalties, including when
+          the Licensed Material is used other than for NonCommercial
+          purposes.
 
 
 Section 3 -- License Conditions.
@@ -265,7 +276,6 @@ following conditions.
           reasonable to satisfy the conditions by providing a URI or
           hyperlink to a resource that includes the required
           information.
-
        3. If requested by the Licensor, You must remove any of the
           information required by Section 3(a)(1)(A) to the extent
           reasonably practicable.
@@ -277,7 +287,7 @@ following conditions.
 
        1. The Adapter's License You apply must be a Creative Commons
           license with the same License Elements, this version or
-          later, or a BY-SA Compatible License.
+          later, or a BY-NC-SA Compatible License.
 
        2. You must include the text of, or the URI or hyperlink to, the
           Adapter's License You apply. You may satisfy this condition
@@ -297,14 +307,15 @@ apply to Your use of the Licensed Material:
 
   a. for the avoidance of doubt, Section 2(a)(1) grants You the right
      to extract, reuse, reproduce, and Share all or a substantial
-     portion of the contents of the database;
+     portion of the contents of the database for NonCommercial purposes
+     only;
 
   b. if You include all or a substantial portion of the database
      contents in a database in which You have Sui Generis Database
      Rights, then the database in which You have Sui Generis Database
      Rights (but not its individual contents) is Adapted Material,
-
      including for purposes of Section 3(b); and
+
   c. You must comply with the conditions in Section 3(a) if You Share
      all or a substantial portion of the contents of the database.
 
@@ -404,24 +415,23 @@ Section 8 -- Interpretation.
      that apply to the Licensor or You, including from the legal
      processes of any jurisdiction or authority.
 
-
 =======================================================================
 
-Creative Commons is not a party to its public licenses.
-Notwithstanding, Creative Commons may elect to apply one of its public
-licenses to material it publishes and in those instances will be
-considered the “Licensor.” The text of the Creative Commons public
-licenses is dedicated to the public domain under the CC0 Public Domain
-Dedication. Except for the limited purpose of indicating that material
-is shared under a Creative Commons public license or as otherwise
-permitted by the Creative Commons policies published at
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
 creativecommons.org/policies, Creative Commons does not authorize the
 use of the trademark "Creative Commons" or any other trademark or logo
 of Creative Commons without its prior written consent including,
 without limitation, in connection with any unauthorized modifications
 to any of its public licenses or any other arrangements,
 understandings, or agreements concerning use of licensed material. For
-the avoidance of doubt, this paragraph does not form part of the public
-licenses.
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
 
 Creative Commons may be contacted at creativecommons.org.

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,17 @@ Attribution-NonCommercial-ShareAlike 4.0 International
 
 =======================================================================
 
+Additional License
+
+If anyone contributes to this document, the contribution is 
+granted right to SakuraFrp for Commercial usage.
+
+If anyone copy, redistribute, remix, transform and build upon
+the material licensed with this license, your changes is considered
+as a contribution to the origin repository.
+
+=======================================================================
+
 Creative Commons Corporation ("Creative Commons") is not a law firm and
 does not provide legal services or legal advice. Distribution of
 Creative Commons public licenses does not create a lawyer-client or

--- a/about.md
+++ b/about.md
@@ -2,7 +2,7 @@
 
 ## 版权及授权协议 :id=license
 
-本文档采用 **CC-BY-SA-4.0 协议** 发布，您可以在 [此处](https://github.com/natfrp/wiki/blob/master/LICENSE ':target=_blank') 查看完整的 LICENSE 文件。
+本文档采用 [CC-BY-NC-SA-4.0 协议](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.zh-Hans) 发布，您可以在 [此处](https://github.com/natfrp/wiki/blob/master/LICENSE ':target=_blank') 查看完整的 LICENSE 文件。
 
 本文档中有引用部分已经注明原作者，在此表示感谢。如有错误或疏漏，请提交 [Issue](https://github.com/natfrp/wiki/issues ':target=_blank') 或发起 [Pull Request](https://github.com/natfrp/wiki/pulls ':target=_blank') 帮助我们进行更正。您也可以直接 [联系我们](#concat-us)。
 

--- a/about.md
+++ b/about.md
@@ -2,7 +2,7 @@
 
 ## 版权及授权协议 :id=license
 
-本文档采用 [CC-BY-NC-SA-4.0 协议](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.zh-Hans) 发布，您可以在 [此处](https://github.com/natfrp/wiki/blob/master/LICENSE ':target=_blank') 查看完整的 LICENSE 文件。
+本文档采用 [CC-BY-NC-SA-4.0 协议](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.zh-Hans) 发布，但是有额外的条款，您可以在 [此处](https://github.com/natfrp/wiki/blob/master/LICENSE ':target=_blank') 查看完整的 LICENSE 文件。
 
 本文档中有引用部分已经注明原作者，在此表示感谢。如有错误或疏漏，请提交 [Issue](https://github.com/natfrp/wiki/issues ':target=_blank') 或发起 [Pull Request](https://github.com/natfrp/wiki/pulls ':target=_blank') 帮助我们进行更正。您也可以直接 [联系我们](#concat-us)。
 

--- a/frpc/service/openwrt.md
+++ b/frpc/service/openwrt.md
@@ -1,16 +1,16 @@
 # OpenWRT 配置 开机启动 服务
 
-?> 查看此教程前请确保您已阅读 [Linux 使用教程](/frpc/usage/linux)
+?> 查看此文档前请确保您已阅读 [Linux 使用](/frpc/usage/linux)
 
-### 前置知识
+### 相关知识
 
-这里使用 [procd init script](https://openwrt.org/docs/guide-developer/procd-init-scripts) 来实现开机自启动
+建议在 OpenWRT 中使用 [procd init script](https://openwrt.org/docs/guide-developer/procd-init-scripts) 来实现开机自启动
 
-需要注意的是 Openwrt 自 bb(Barrier Breaker) 后引入了该系统，如果您使用 aa 或更早的上古系统，请使用 sysV 格式写启动脚本
+需要注意的是 Openwrt 自 bb(Barrier Breaker) 后引入了该系统，如果您使用 aa 或更早的上古系统，您可能需要使用 sysV 格式写启动脚本
 
 对于存储空间不足的路由器，可能需要（~换一个~）[使用 UPX 压缩二进制文件体积](https://github.com/upx/upx/releases)
 
-### 前置问题排除
+### 问题排除
 
 对于 Openwrt 用户来说，因为路由器的软件常年永不更新，视固件的年代，可能出现这样的错误：
 
@@ -31,38 +31,6 @@ opkg install ca-certificates
 1. 使用`tar cf`打包它的`/etc/ssl/certs`目录
 1. 迁移到你的路由器同目录中
 
-### 添加步骤如下
+### LuCI GUI 操作 :id=luci
 
-1. 新建开机启动脚本：/etc/init.d/frp 脚本代码如下：
-
-```bash
-#!/bin/sh /etc/rc.common
-# Copyright (C) 2008 OpenWrt.org
-
-START=99
-USE_PROCD=1
-PROG="/usr/local/bin/frpc_linux_mipsle" #根据你自己的frp客户端填写
-
-start_service() {
-    rm -f /frpc_overload*.log* # remove old logt/logp files
-    procd_open_instance
-    procd_set_param command "$PROG"
-    procd_append_param command -f <访问密钥>:隧道ID,隧道ID...
-    procd_set_param stdout 1 # forward stdout of the command to logd
-    procd_set_param stderr 1 # same for stder
-    procd_set_param respawn
-    procd_close_instance
-}
-```
-
-2. 设置运行权限，打开开机自启动：
-
-```bash
-chmod +x /etc/init.d/frp && /etc/init.d/frp enable
-```
-
-3. 此时系统每次开机就会自动启动服务了，当然你也可以手动启动服务
-
-```bash
-/etc/init.d/frp start
-```
+目前我们暂时不提供 LuCI app 支持, 但是我们为某著名的小白化 lede 固件的 luci-app 提供了[更新](https://github.com/coolsnowwolf/lede/pull/6496), 以确保它可以正常使用


### PR DESCRIPTION
近期出现了有小型商业项目复制本文档中的内容，但是没有给出协议要求的合适的署名的情况出现。因为我们在文档中投入较多的精力，这种行为无疑是不可接受的。

为了杜绝只看 license 名字 和 cc 的 deed 就猜条款的天才行为出现，我们可以切换到 CC-BY-NC-SA，以在名称中明确非商用的方式防止此问题的发生。