### PR TITLE
 frpc/service/systemd: 遵守通常发行版的unit path约定

### DIFF
--- a/frpc/service/systemd.md
+++ b/frpc/service/systemd.md
@@ -17,15 +17,15 @@ Systemd 的服务有两种状态:
 ### 编写配置文件
 
 Systemd 的 **Unit 配置文件** 通常位于这些目录中:
-  - /lib/systemd/system
-  - /etc/systemd/system
+  - /lib/systemd/system （供软件包使用）
+  - /etc/systemd/system （供管理员使用）
 
-本教程将选用第一个目录来放置 frpc 的 **Unit 配置文件**，并且 frpc 启用后报错退出时每分钟会自动重启一次
+本教程将选用第二个目录来放置 frpc 的 **Unit 配置文件**，并且 frpc 启用后报错退出时每分钟会自动重启一次
 
 执行下面的命令，您应该会看到图中的提示
 
 ```bash
-# vi /lib/systemd/system/frpc@.service
+# vi /etc/systemd/system/frpc@.service
 ```
 
 ![](_images/systemd-0.png)


### PR DESCRIPTION
根据Archlinux wiki[^1] 和 openSUSE wiki[^2] 所述，由于sakurafrp在Linux平台没有成为一个软件包，因此对它的服务配置应该放在 <code>/etc/systemd/system</code> 下
[^1]:https://wiki.archlinux.org/title/Systemd_(%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87)#%E7%BC%96%E5%86%99%E5%8D%95%E5%85%83%E6%96%87%E4%BB%B6
[^2]:https://zh.opensuse.org/openSUSE:How_to_write_a_systemd_service