### PR TITLE
offtopic/mc-bds&frpc/ssl: Update for 1.19.30 and correction

### DIFF
--- a/frpc/ssl.md
+++ b/frpc/ssl.md
@@ -12,7 +12,7 @@
 ## 获取 SSL 证书 :id=ssl
 
 > 如果您还不知道如何设置、申领 SSL 证书，请阅读此章节。
-否则，请直接跳到 [后续内容](#auto-https)。
+否则，请直接跳到 [后续内容](#autohttps)。
 
 ### 选择 SSL 服务商 :id=ssl-choose
 

--- a/offtopic/mc-bedrock-server.md
+++ b/offtopic/mc-bedrock-server.md
@@ -199,18 +199,22 @@ emit-server-telemetry = true
 
 disable-player-interaction = false
 # 是否禁用玩家间交互
-# 仅在 1.19.20 及更高版本的服务端中生效。
+# 仅在 1.19.20.02 及更高版本的服务端中生效。
 # 允许值:
 #   是: true
 #   否: false
 
-chat-restriction = none
+chat-restriction = None
 # 是否限制玩家聊天
-# 仅在 1.19.20 及更高版本的服务端中生效。
+# 仅在 1.19.20.02 及更高版本的服务端中生效。
 # 允许值:
-#   不限制: none
-#   部分限制: dropped
-#   完全限制: disabled
+#   不限制: None
+#   部分限制: Dropped
+#   完全限制: Disabled
+
+disable-custom-skins = false
+# 是否在服务器范围内禁用指定指定皮肤
+# 仅在 1.19.30 及更高版本的服务端钟生效。
 ```
 #### 隧道配置
 


### PR DESCRIPTION
- 在 Minecraft 基岩版开服指南的 `server.peoperties` 配置文件中 **同步了 1.19.30 的修改内容**，并 **修正了部分错误**
- 在 frpc 的 配置 SSL 证书 页面中，修正了一个无效的跳转链接。