### PR TITLE
ot/mc-bds&geyser: Update server.properties file for new BDS/JEServer versions

### DIFF
--- a/about.md
+++ b/about.md
@@ -73,7 +73,7 @@ contributors: false
   - _咕_
 - [一纸荒年Trace](https://wtrace3zh.com)
   - _Source 引擎游戏开服指南 帮助文档_
-- [红羽早苗](https://fro.moe)
+- [红羽早苗](https://www.natfrpbbs.com/members/1/)
   - _邮件服务穿透、Minecraft 穿透及开服指南 部分帮助文档_
   - _社区论坛站点_
   - _不咕_

--- a/offtopic/mc-bedrock-server.md
+++ b/offtopic/mc-bedrock-server.md
@@ -107,6 +107,13 @@ server-portv6 = 19132
 # 服务端应监听哪个IPv6端口。
 # 允许值: [1, 65535]
 
+enable-lan-visibility = true
+# 是否使服务器在局域网 (好友界面) 可见
+# 仅在 1.19.50 及更高版本的服务端中生效。
+# 允许值:
+#   是: true
+#   否: false
+
 view-distance = 32
 # 允许的最大视距 (以方块数为单位) 。
 # 允许值: [1, ∞]
@@ -152,6 +159,12 @@ content-log-file-enabled = false
 compression-threshold = 1
 # 要压缩的原始网络有效负载的最小大小
 # 允许值 : [0, 65535]
+
+compression-algorithm = zlib
+# 网络连接使用的压缩算法
+# 允许值:
+#   zlib 算法: zlib
+#   Snappy 算法: snappy
 
 server-authoritative-movement = true
 # 启用服务端权威性移动。
@@ -214,14 +227,7 @@ disable-custom-skins = false
 #   是: true
 #   否: false
 
-enable-lan-visibility = true
-# 是否使服务器在局域网 (好友界面) 可见
-# 仅在 1.19.50 及更高版本的服务端中生效。
-# 允许值:
-#   是: true
-#   否: false
-
-# block-network-ids-are-hashes = true
+block-network-ids-are-hashes = true
 # 是否使服务端发送散列的方块网络 ID，这些 ID 不会被随意更改
 # 设为 false 时，将发送从 0 开始递增的 ID。
 # 仅在 1.20.10.20 及更高版本的服务端中生效。
@@ -229,7 +235,7 @@ enable-lan-visibility = true
 #   是: true
 #   否: false
 
-# server-build-radius-ratio = Disabled
+server-build-radius-ratio = Disabled
 # 是否根据覆盖比率的多少来生成玩家的视距，不考虑客户端的硬件功能
 # 设为 false 时，将由服务器动态计算玩家的视距多少。
 # 仅在 client-side-chunk-generation-enabled 配置项启用时生效

--- a/offtopic/mc-geyser.md
+++ b/offtopic/mc-geyser.md
@@ -383,12 +383,12 @@ max-world-size = 29999984
 # 设置最大的世界边界半径，单位为方块。
 # 允许值: [1, 29999984]
 
-# max-chained-neighbor-updates = 0
+max-chained-neighbor-updates = 0
 # 设置连锁更新 NC 的数量，超过此限制的 NC 更新会被跳过。若为负数则无限制。
 # 仅在 1.19 及更高版本有效。
 # 允许值: [∞, ∞]
 
-# enforce-secure-profile = true
+enforce-secure-profile = true
 # 是否强制要求使用签名公钥
 # 启用后，玩家必须具有由 Mojang 签名的公钥，才能进入服务器。
 # 仅在 1.19 及更高版本有效，1.19 默认值为 false。
@@ -410,6 +410,13 @@ initial-disabled-packs =
 initial-enabled-packs = vanilla
 # 在创建世界过程中，需要启用并加载的数据包名称
 # 仅在 1.19.3 及更高版本有效。
+
+log-ips = true
+# 新玩家加入时，是否将其 IP 地址记录到日志文件中
+# 仅在 1.20.2 及更高版本有效。
+# 允许值:
+#   是: true
+#   否: false
 ```
 
 ### 编辑 Geyser 服务端配置文件


### PR DESCRIPTION
'ot/mc-bds'
- 挪动了 'enable-lan-visibility' 配置项的位置，以使它和现有默认配置文件的位置一致
- 加入了 'compression-algorithm' 配置项，先前遗漏了
- 删除部分多余的 # 号

'ot/mc-geyser'
- 删除部分多余的 # 号
- 新增 JE1.20.2 加入的 'log-ips' 配置项

'about'
- 个人博客停用了，于是链接改成社区论坛账户（