### PR TITLE
launcher/usage: 更新macOS相关说明

### DIFF
--- a/launcher/usage.md
+++ b/launcher/usage.md
@@ -50,7 +50,8 @@
 
 @tab macOS {#macos}
 ::: warning
-启动器仅适用于 macOS 11 Big Sur 及以上版本，如您还在使用更古老的版本请参考[Docker方式](/launcher/usage.html#docker)使用启动器或者[安装frpc](/frpc/usage.html#macos)
+受限于苹果在 2020 年发布的程序框架中取消支持了自己在 2019 年底公开发布的系统，启动器仅适用于 macOS 11 Big Sur 及以上版本，  
+如您还在使用更古老的版本请 **终端直接使用启动器** 或者 [使用 frpc (不推荐)](/frpc/usage.html#macos)。
 :::
 
 打开下载的 `.dmg` 文件，然后按箭头指示将启动器拖到 `Applications` 文件夹中即可：
@@ -363,8 +364,11 @@ userdel -r natfrp
    ```
 
    ::: warning
-   非Linux系统 (Windows,macOS) 不支持 `--network=host`
-   请将 `--network=host` 更改为 `-p 4101:4101`，这将会把4101端口映射到localhost (127.0.0.1)
+   非 Linux 系统 (Windows, macOS) 不支持 `--network=host`，  
+   我们推荐您不要在此情况下使用启动器，这可能会造成很差的使用体验。
+
+   您如果执意要如此做，可能需要将 `--network=host` 更改为 `-p 4101:4101`，这将会把 4101 端口映射到 localhost (127.0.0.1)。
+   同时请将隧道本地 IP 修改为 docker 网关地址或者局域网访问地址。
    :::
 
    如果您卡在了 `Pulling from natfrp/launcher`，请尝试将最后一行 `natfrp/launcher` 替换为 `registry.cn-hongkong.aliyuncs.com/natfrp/launcher`。

--- a/launcher/usage.md
+++ b/launcher/usage.md
@@ -49,6 +49,9 @@
 1. 如果需要卸载系统服务，点击 `卸载服务` 按钮即可
 
 @tab macOS {#macos}
+::: warning
+启动器仅适用于 macOS 11 Big Sur 及以上版本，如您还在使用更古老的版本请参考[Docker方式](/launcher/usage.html#docker)使用启动器或者[安装frpc](/frpc/usage.html#macos)
+:::
 
 打开下载的 `.dmg` 文件，然后按箭头指示将启动器拖到 `Applications` 文件夹中即可：
 
@@ -359,11 +362,16 @@ userdel -r natfrp
       natfrp/launcher
    ```
 
+   ::: warning
+   非Linux系统 (Windows,macOS) 不支持 `--network=host`
+   请将 `--network=host` 更改为 `-p 4101:4101`，这将会把4101端口映射到localhost (127.0.0.1)
+   :::
+
    如果您卡在了 `Pulling from natfrp/launcher`，请尝试将最后一行 `natfrp/launcher` 替换为 `registry.cn-hongkong.aliyuncs.com/natfrp/launcher`。
 
    如果您遇到了错误 `Bind for 0.0.0.0:4101 failed: port is already allocated`，请查找本机监听 4101 的程序关闭，或参考 [高级用户](#advance-docker) 替换监听端口。
 
-3. 获取连接信息
+4. 获取连接信息
 
    执行 `docker logs natfrp-service` 即可查看容器的日志，您将看到类似下面的回显内容：
 
@@ -387,7 +395,7 @@ userdel -r natfrp
    默认情况下 WebUI 向您连入的所有网络开放，如果您需要访问，可以使用 `https://内网IP:<端口>`，
    如果您需要修改监听 IP，请参考 [高级用户](#advance-docker)。
 
-4. 高级用户 {#advance-docker}
+5. 高级用户 {#advance-docker}
 
    如果您需要自行配置，请先阅读 [配置文件详解](/launcher/manual.md#config)，然后将容器内的 `/run/config.json` 挂载编辑即可。
 

--- a/launcher/usage.md
+++ b/launcher/usage.md
@@ -371,7 +371,7 @@ userdel -r natfrp
 
    如果您遇到了错误 `Bind for 0.0.0.0:4101 failed: port is already allocated`，请查找本机监听 4101 的程序关闭，或参考 [高级用户](#advance-docker) 替换监听端口。
 
-4. 获取连接信息
+3. 获取连接信息
 
    执行 `docker logs natfrp-service` 即可查看容器的日志，您将看到类似下面的回显内容：
 
@@ -395,7 +395,7 @@ userdel -r natfrp
    默认情况下 WebUI 向您连入的所有网络开放，如果您需要访问，可以使用 `https://内网IP:<端口>`，
    如果您需要修改监听 IP，请参考 [高级用户](#advance-docker)。
 
-5. 高级用户 {#advance-docker}
+4. 高级用户 {#advance-docker}
 
    如果您需要自行配置，请先阅读 [配置文件详解](/launcher/manual.md#config)，然后将容器内的 `/run/config.json` 挂载编辑即可。
 


### PR DESCRIPTION
- 经群友反馈，在macOS 10.15.7上安装启动器时提示需要macOS 11以上
- 在非linux系统下无host网络模式 ([解决方案参考](https://docs.docker.com/desktop/networking/#i-want-to-connect-to-a-container-from-the-host))