### PR TITLE
offtopic/mc-java-server: 添加Adoptium Java的清华镜像下载链接

### DIFF
--- a/offtopic/mc-java-server.md
+++ b/offtopic/mc-java-server.md
@@ -53,6 +53,14 @@ cond3(no@大于或等于, right)->Java 21
 | --- | --- | --- |
 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=8)<br>点击 `.msi` 下载 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=17)<br>点击 `.msi` 下载 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=21)<br>点击 `.msi` 下载 |
 
+::: tip
+由于其下载地址位于境外，下载速度可能较慢或无法下载，此时可以使用下列[清华大学镜像站](https://mirrors.tuna.tsinghua.edu.cn/)镜像链接下载
+:::
+
+| Java 8 | Java 17 | Java 21 |
+| --- | --- | --- |
+| [下载链接](https://mirrors.tuna.tsinghua.edu.cn/Adoptium/8/jre/x64/windows/)<br>点击带有 `.msi` 后缀的文件下载 | [下载链接](https://mirrors.tuna.tsinghua.edu.cn/Adoptium/17/jre/x64/windows/)<br>点击带有 `.msi` 后缀的文件下载 | [下载链接](https://mirrors.tuna.tsinghua.edu.cn/Adoptium/21/jre/x64/windows/)<br>点击带有 `.msi` 后缀的文件下载 |
+
 @tab Zulu
 
 由知名 Java 开发企业 Azul 制作的 Java 环境安装包。

--- a/offtopic/mc-java-server.md
+++ b/offtopic/mc-java-server.md
@@ -54,7 +54,7 @@ cond3(no@大于或等于, right)->Java 21
 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=8)<br>点击 `.msi` 下载 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=17)<br>点击 `.msi` 下载 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=21)<br>点击 `.msi` 下载 |
 
 ::: tip
-由于其下载地址位于境外，下载速度可能较慢或无法下载，此时可以使用下列[清华大学镜像站](https://mirrors.tuna.tsinghua.edu.cn/)镜像链接下载
+由于其下载地址位于境外，下载速度可能较慢或无法下载，此时可以使用下列 [清华大学镜像站](https://mirrors.tuna.tsinghua.edu.cn/) 镜像链接下载
 :::
 
 | Java 8 | Java 17 | Java 21 |

--- a/offtopic/mc-java-server.md
+++ b/offtopic/mc-java-server.md
@@ -49,17 +49,14 @@ cond3(no@大于或等于, right)->Java 21
 
 由 Eclipse 开源基金会创建、阿里巴巴、华为、IBM 等参与的 Java 环境项目。
 
-| Java 8 | Java 17 | Java 21 |
-| --- | --- | --- |
-| [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=8)<br>点击 `.msi` 下载 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=17)<br>点击 `.msi` 下载 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=21)<br>点击 `.msi` 下载 |
-
 ::: tip
 由于其下载地址位于境外，下载速度可能较慢或无法下载，此时可以使用下列 [清华大学镜像站](https://mirrors.tuna.tsinghua.edu.cn/) 镜像链接下载
 :::
 
-| Java 8 | Java 17 | Java 21 |
-| --- | --- | --- |
-| [下载链接](https://mirrors.tuna.tsinghua.edu.cn/Adoptium/8/jre/x64/windows/)<br>点击带有 `.msi` 后缀的文件下载 | [下载链接](https://mirrors.tuna.tsinghua.edu.cn/Adoptium/17/jre/x64/windows/)<br>点击带有 `.msi` 后缀的文件下载 | [下载链接](https://mirrors.tuna.tsinghua.edu.cn/Adoptium/21/jre/x64/windows/)<br>点击带有 `.msi` 后缀的文件下载 |
+| 下载源 | Java 8 | Java 17 | Java 21 |
+| --- | --- | --- | --- |
+| 官方源 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=8)<br>点击 `.msi` 下载 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=17)<br>点击 `.msi` 下载 | [下载链接](https://adoptium.net/zh-CN/temurin/releases/?os=windows&arch=x64&package=jre&version=21)<br>点击 `.msi` 下载 |
+| 清华镜像源 | [下载链接](https://mirrors.tuna.tsinghua.edu.cn/Adoptium/8/jre/x64/windows/)<br>点击带有 `.msi` 后缀的文件下载 | [下载链接](https://mirrors.tuna.tsinghua.edu.cn/Adoptium/17/jre/x64/windows/)<br>点击带有 `.msi` 后缀的文件下载 | [下载链接](https://mirrors.tuna.tsinghua.edu.cn/Adoptium/21/jre/x64/windows/)<br>点击带有 `.msi` 后缀的文件下载 |
 
 @tab Zulu
 


### PR DESCRIPTION
如题，因为Adoptium的下载链接是从github release来的

https://github.com/adoptium/temurin8-binaries/releases
https://github.com/adoptium/temurin17-binaries/releases
https://github.com/adoptium/temurin21-binaries/releases