### PR TITLE
app/mc; launcher/usage; faq/client-error: 多处小修改

### DIFF
--- a/app/mc.md
+++ b/app/mc.md
@@ -54,8 +54,8 @@ Minecraft 局域网联机穿透通常需要安装 Mod 辅助，
 ### 安装辅助 Mod 联机 {#java-mod}
 
 ::: warning
-通过辅助 Mod 关闭正版验证 **可能** 会改变玩家的 UUID 导致 **背包内物品和玩家数据丢失**，请在操作前 **备份存档**  
-辅助 Mod 互相 **不兼容**，请勿 **重复** 添加联机模组
+通过辅助 Mod 关闭正版验证可能会改变玩家的 UUID 导致 **背包内物品和玩家数据丢失**，请在操作前 **备份存档**  
+辅助 Mod 互相不兼容，请勿重复添加联机模组
 :::
 
 如果您游玩的是整合包，那么其内可能已经有联机 Mod，您可以通过在游戏内打开 `对局域网开放` 功能时是否有 `在线模式` / `正版验证` 的配置来判断。  
@@ -81,10 +81,10 @@ Minecraft 局域网联机穿透通常需要安装 Mod 辅助，
 
 :::: tabs
 
-@tab LAN World Plug-n-Play
+@tab LAN World Plug-n-Play (推荐)
 
 ::: tip
-这个模组会显示 *端口映射失败，请使用内网映射软件* *获取IP成功: 内网IPv4* 等模组其他功能的运行状态，**请忽略这些提示**。  
+这个模组会在聊天栏显示 *端口映射失败，请使用内网映射软件* *获取IP成功: 内网IPv4* 等模组其他功能的运行状态，**请忽略这些提示**。  
 您的客机需要连接的 IP 在启动器或 frpc 的日志中。
 :::
 
@@ -94,15 +94,16 @@ Minecraft 局域网联机穿透通常需要安装 Mod 辅助，
   2. 开关在线模式 (Online-mode)
   3. 更多对其他人的自定义功能
   4. 通过uPnP功能进行联机
-- 发布页面: [mcmod](https://www.mcmod.cn/class/4498.html) | [modrinth](https://modrinth.com/mod/mcwifipnp/) | [Curseforge](https://www.curseforge.com/minecraft/mc-mods/mcwifipnp/)
+- 发布页面: [mcmod](https://www.mcmod.cn/class/4498.html) | [modrinth](https://modrinth.com/mod/mcwifipnp/) | [Curseforge](https://www.curseforge.com/minecraft/mc-mods/mcwifipnp/) | [Github](https://github.com/Satxm/mcwifipnp)
 
 #### 使用方法
 
-1. 安装 Mod 并进入游戏，打开您要联机的世界
-2. 按下键盘上的 **ESC** 键，在出现的界面里找到 `对局域网开放` 之类的按钮并且点击进入
-3. 安装此 Mod 后 **设置局域网世界** 界面会增加下列选项，请按需配置:
+1. 安装 Mod 并进入游戏，进入您要和朋友联机的世界
+2. 按下 **ESC** 键，进入暂停菜单 (Pause Menu)，找到 `对局域网开放` 按钮并点击进入
+3. 安装此 Mod 后 **局域网世界** 界面会增加下列选项，请按需配置:
+  （注：您所看到的界面可能会因为版本不同而与教程有所差别，请尝试切换标签页寻找对应开关）
   ![](./_images/mc-mcwifipnp-setting.png)
-4. 点击 `创建局域网世界`，在聊天栏中会提示 `本地游戏已在端口 xxxxx 上开启`，表示游戏内置服务端已经启动，这个五位数的端口号会固定为您在上面输入框中设置的端口号。对应您在创建隧道时的本地端口选项。
+4. 点击 `创建局域网世界`，在聊天栏中会提示 `本地游戏已在端口 xxxxx 上开启`，表示游戏内置服务端已经启动，这个五位数的端口号会固定为您在上面输入框中设置的端口号。
 
 @tab LanServerProperties
 

--- a/faq/client-error.md
+++ b/faq/client-error.md
@@ -29,6 +29,10 @@
 
 ## 无法连接到本地服务 {#connect-to-local-service-error}
 
+::: tip
+如果您正在映射 `Minecraft Java` 游戏服务，建议您查看更有针对性的 [MC穿透常见问题](app/mc.html#connect-to-local-service-error) 页面
+:::
+
 此日志说明 **frpc 工作正常**，但是 frpc 无法连接到您的本地服务。
 
 | 原因 | 解决方案 |

--- a/launcher/usage.md
+++ b/launcher/usage.md
@@ -58,7 +58,7 @@
 
 ![](./_images/windows-install-components.png)
 
-## 关于开机启动 {#windows-autostart}
+### 关于开机启动 {#windows-autostart}
 
 打开启动器设置里的开关，就能实现登入桌面后自动启动隧道：
 
@@ -66,7 +66,7 @@
 
 如果需要不登录 Windows 就启动隧道（例如穿透远程桌面服务），请参考下面的说明安装系统服务。
 
-## 安装系统服务 {#windows-service}
+### 安装系统服务 {#windows-service}
 
 如果您正在安装启动器，直接勾选 `安装为系统服务` 并完成安装即可。否则，请按下面的步骤操作：
 
@@ -104,7 +104,7 @@
 
 ![](./_images/macos-install.png)
 
-## 关于开机启动 {#macos-autostart}
+### 关于开机启动 {#macos-autostart}
 
 如果需要在启动时自动打开用户界面，请参考 Apple 帮助文档：[Mac 启动时自动打开应用](https://support.apple.com/zh-cn/guide/mac-help/mh15189/mac)
 
@@ -121,6 +121,8 @@
 如果您不需要安装到系统级，请参考 [Linux (无 Root 桌面)](#linux) 标签
 :::
 
+### 脚本安装 {#linux-script-install}
+
 对于使用 systemd 的用户，可使用一键安装脚本快速安装：
 
 ```bash
@@ -134,6 +136,14 @@ sudo bash -c ". <(curl -sSL https://doc.natfrp.com/launcher.sh) direct"
 ```
 
 此脚本于 [PR#526](https://github.com/natfrp/wiki/pull/526) 中由用户 [ssdomei232](https://github.com/ssdomei232) 贡献并经我们修改。
+
+### 脚本卸载 {#linux-script-uninstall}
+
+对于使用 [一键脚本](#linux-script-install) 安装的用户，可以使用脚本的卸载功能来快速卸载：
+
+```bash
+sudo bash -c ". <(curl -sSL https://doc.natfrp.com/launcher.sh) uninstall"
+```
 
 ### 手动安装步骤 {#linux-server-manual}
 
@@ -251,7 +261,7 @@ sudo bash -c ". <(curl -sSL https://doc.natfrp.com/launcher.sh) direct"
 
    ![](./_images/remote-v2-connect-2.png)
 
-### 关于卸载方式 {#linux-uninstall}
+### 手动卸载步骤 {#linux-manual-uninstall}
 
 如果您是按照教程安装的，把安装过程中进行的操作反过来进行一遍即可。
 
@@ -313,6 +323,8 @@ userdel -r natfrp
    ![](./_images/remote-v2-connect-2.png)
 
 @tab Docker {#docker}
+
+### Docker安装步骤 {#docker-install}
 
 如果您的系统中已有 Docker 环境，可使用一键安装脚本快速安装：
 


### PR DESCRIPTION
app/mc: 去除过分重复的加粗，添加补充部分内容。
launcher/usage: 添加 linux 脚本卸载方式，统一部分标题级数。
faq/client-error: 连接到 Minecraft 常见问题排查文档。